### PR TITLE
Show module revision when pulling

### DIFF
--- a/osbuild/build.py
+++ b/osbuild/build.py
@@ -135,6 +135,8 @@ def _pull_module(module, revision=None):
     except subprocess.CalledProcessError:
         return False
 
+    print("\trev: {0}".format(git_module.get_head()))
+
     state.pulled_module_touch(module)
 
     return True

--- a/osbuild/git.py
+++ b/osbuild/git.py
@@ -190,6 +190,10 @@ class Module:
 
         return result
 
+    def get_head(self):
+        os.chdir(self.local)
+        return subprocess.check_output(["git", "rev-parse", "HEAD"]).strip()
+
 
 def get_module(module):
     return Module(path=config.get_source_dir(),


### PR DESCRIPTION
"get_head" method is based on "_get_head" from https://github.com/dnarvaez/osbuild/blob/master/osbuild/tests/test_git.py#L32

Screenshot with example output
http://snag.gy/nwCwc.jpg

Tests and lint:
`python setup.py lint test` successful
